### PR TITLE
Корректнее использовать ActiveTab

### DIFF
--- a/Сниппеты/[Капчи]/[ReCaptcha]/Проверка присутствия на странице.cs
+++ b/Сниппеты/[Капчи]/[ReCaptcha]/Проверка присутствия на странице.cs
@@ -4,8 +4,8 @@
 * Выходит по красной ветке если рекапча не найдена.
 */
 
-if ((instance.MainTab.DomText.IndexOf("//www.google.com/recaptcha/api2/anchor") > -1) ||
-    (instance.MainTab.DomText.IndexOf("recaptcha.anchor.Main.init") > -1))
+if ((instance.ActiveTab.DomText.IndexOf("//www.google.com/recaptcha/api2/anchor") > -1) ||
+    (instance.ActiveTab.DomText.IndexOf("recaptcha.anchor.Main.init") > -1))
 {
     return "found";
 }


### PR DESCRIPTION
Это именно **активная** вкладка, а не какая-то другая. По дефолту в ZP во встроенных методах используется именно ActiveTab